### PR TITLE
Fix #24, #25: Pest speed scaling and duplicate boss defeat logic

### DIFF
--- a/script.js
+++ b/script.js
@@ -70,7 +70,7 @@ function spawnPest() {
     word: word,
     typed: "",
     position: 100,
-    speed: 0.2 + Math.random() * 0.2,
+    speed: (0.2 + currentStage * 0.1) + Math.random() * 0.2,
     typedSpan: typedSpan,
     untypedSpan: untypedSpan
   };
@@ -130,28 +130,16 @@ function handleKeyPress(event) {
           }, 200);
 
           if (pest.hp <= 0) {
-  score += 100;
-  showPopup(pest.element, "+100", "score");
-  pest.element.remove();
-  activePests.splice(i, 1);
+            score += 100;
+            showPopup(pest.element, "+100", "score");
+            pest.element.remove();
+            activePests.splice(i, 1);
 
-  document.getElementById("boss-hp-container").style.display = "none";
+            document.getElementById("boss-hp-container").style.display = "none";
 
-  // Boss defeated = menang!
-  showEndScreen("Selamat! Kamu Menang!");
-}
-            if (pest.hp <= 0) {
-              score += 100;
-              showPopup(pest.element, "+100", "score");
-              pest.element.remove();
-              activePests.splice(i, 1);
-
-              document.getElementById("boss-hp-container").style.display = "none";
-
-              // Boss defeated = menang!
-              showEndScreen("Selamat! Kamu Menang!");
-            }
-            else {
+            // Boss defeated = menang!
+            showEndScreen("Selamat! Kamu Menang!");
+          } else {
             // Ganti kata boss berikutnya
             pest.currentWordIndex++;
             if (pest.currentWordIndex >= pest.bossWords.length) {


### PR DESCRIPTION
## Bug Fixes

This PR fixes two bugs reported in issues #24 and #25.

### Fix #25: Pest speed does not scale with stage difficulty
- **Problem:** Pest speed was hardcoded to `0.2 + Math.random() * 0.2` regardless of stage
- **Solution:** Changed to `(0.2 + currentStage * 0.1) + Math.random() * 0.2`
- **Result:** 
  - Stage 1: 0.2-0.4 speed
  - Stage 2: 0.3-0.5 speed  
  - Stage 3: 0.4-0.6 speed

### Fix #24: Boss defeat logic duplicated causing score to be awarded twice
- **Problem:** The `if (pest.hp <= 0)` block was copy-pasted twice, causing +200 score instead of +100
- **Solution:** Removed the duplicate block
- **Result:** Boss defeat now correctly awards +100 score once

## Testing
- Pest speed visibly increases with each stage
- Boss defeat awards exactly +100 points

## Files Changed
- `script.js`: 9 insertions, 21 deletions

---

🤖 Generated by **Claw (AI Agent)**