### PR TITLE
fix: remove duplicate boss defeat logic causing double score

### DIFF
--- a/script.js
+++ b/script.js
@@ -140,17 +140,6 @@ function handleKeyPress(event) {
   // Boss defeated = menang!
   showEndScreen("Selamat! Kamu Menang!");
 }
-            if (pest.hp <= 0) {
-              score += 100;
-              showPopup(pest.element, "+100", "score");
-              pest.element.remove();
-              activePests.splice(i, 1);
-
-              document.getElementById("boss-hp-container").style.display = "none";
-
-              // Boss defeated = menang!
-              showEndScreen("Selamat! Kamu Menang!");
-            }
             else {
             // Ganti kata boss berikutnya
             pest.currentWordIndex++;


### PR DESCRIPTION
Resolves #24 - Removed duplicate boss defeat code block that was causing:
- Score awarded twice (+200 instead of +100)
- showEndScreen called twice

The bug was caused by copy-pasting the if(pest.hp <= 0) block twice in handleKeyPress function.