### PR TITLE
fix: boss defeat duplication and pest speed scaling

### DIFF
--- a/script.js
+++ b/script.js
@@ -70,7 +70,7 @@ function spawnPest() {
     word: word,
     typed: "",
     position: 100,
-    speed: 0.2 + Math.random() * 0.2,
+    speed: (0.2 + Math.random() * 0.2) * (1 + (currentStage - 1) * 0.3),
     typedSpan: typedSpan,
     untypedSpan: untypedSpan
   };
@@ -130,17 +130,6 @@ function handleKeyPress(event) {
           }, 200);
 
           if (pest.hp <= 0) {
-  score += 100;
-  showPopup(pest.element, "+100", "score");
-  pest.element.remove();
-  activePests.splice(i, 1);
-
-  document.getElementById("boss-hp-container").style.display = "none";
-
-  // Boss defeated = menang!
-  showEndScreen("Selamat! Kamu Menang!");
-}
-            if (pest.hp <= 0) {
               score += 100;
               showPopup(pest.element, "+100", "score");
               pest.element.remove();
@@ -150,8 +139,7 @@ function handleKeyPress(event) {
 
               // Boss defeated = menang!
               showEndScreen("Selamat! Kamu Menang!");
-            }
-            else {
+            } else {
             // Ganti kata boss berikutnya
             pest.currentWordIndex++;
             if (pest.currentWordIndex >= pest.bossWords.length) {


### PR DESCRIPTION
## Summary
- **Fix #24**: Remove duplicated boss defeat block that awarded +100 score and called `showEndScreen` twice when boss HP reached 0
- **Fix #25**: Scale pest speed by `currentStage` — 1.0x / 1.3x / 1.6x for stages 1/2/3

## Test plan
- [ ] Defeat boss in stage 3, verify score increments by 100 only once
- [ ] Verify end screen appears only once
- [ ] Observe pest speed increase across stages 1 → 2 → 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)